### PR TITLE
Support match-case with Python 3.10+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+dev_test
+
 # poetry & pyproject.toml based env is not ready & for internal experiment only.
 # keeps setup.py for a while.
 pyproject.toml

--- a/pyflowchart/ast_node.py
+++ b/pyflowchart/ast_node.py
@@ -10,9 +10,25 @@ license that can be found in the LICENSE file.
 import _ast
 from typing import List, Tuple
 
-import astunparse
-
 from pyflowchart.node import *
+
+# import astunparse
+#
+# `astunparse` is a third-party package, that provides a function `unparse` to translate AST into Python source code.
+# This function is included in Python 3.9 std lib as `ast.unparse`.
+# And there are bugs to continue to use `astunparse` in Python 3.9+.
+# So here: we use `astunparse` in Python 3.8- and `ast.unparse` in Python 3.9+.
+#
+# See also:
+#  - https://github.com/cdfmlr/pyflowchart/issues/28
+#  - https://github.com/simonpercivall/astunparse/issues/56#issuecomment-1438353347
+#  - https://docs.python.org/3/library/ast.html#ast.unparse
+import sys
+
+if sys.version_info < (3, 9):
+    import astunparse
+else:
+    import ast as astunparse
 
 
 # TODO: beautify tail connection direction

--- a/pyflowchart/node.py
+++ b/pyflowchart/node.py
@@ -11,7 +11,7 @@ license that can be found in the LICENSE file.
 import time
 import uuid
 import itertools  # for count
-from typing import List, TypeVar
+from typing import List, TypeVar, Optional
 
 # AsNode is a TypeVar for Node and its subclasses
 AsNode = TypeVar('AsNode', bound='Node')
@@ -227,8 +227,9 @@ class NodesGroup(Node):
     NodesGroup.connections is unused.
     """
 
-    def __init__(self, head_node: Node, tail_nodes=None):
+    def __init__(self, head_node: Optional[Node], tail_nodes=None):
         Node.__init__(self)
+        # special case: ParseProcessGraph: head == None
         if tail_nodes is None:
             tail_nodes = []
         self.head = head_node
@@ -406,18 +407,19 @@ class ConditionNode(Node):
         self.node_name = f'cond{self.id}'
         self.node_text = f'{cond}'
 
-        self.connection_yes: Connection = None
-        self.connection_no: Connection = None
+        self.connection_yes: Optional[Connection] = None
+        self.connection_no: Optional[Connection] = None
 
         if not align_next:
             self.no_align_next()
 
-    def connect_yes(self, yes_node: Node, direction: str = ''):
+    def connect_yes(self, yes_node: Optional[Node], direction: str = ''):
+        # yes_node is optional due to the virtual node is connecting to None
         condyn = CondYN(self, CondYN.YES, yes_node)
         self.connection_yes = Connection(condyn, 'yes', direction)
         self.connections.append(self.connection_yes)
 
-    def connect_no(self, no_node: Node, direction: str = ''):
+    def connect_no(self, no_node: Optional[Node], direction: str = ''):
         condyn = CondYN(self, CondYN.NO, no_node)
         self.connection_no = Connection(condyn, 'no', direction)
         self.connections.append(self.connection_no)

--- a/pyflowchart/test.py
+++ b/pyflowchart/test.py
@@ -14,10 +14,16 @@ import ast
 import re
 import unittest
 
-import astunparse
-
 from pyflowchart.ast_node import *
 from pyflowchart.flowchart import *
+
+# import astunparse # https://github.com/cdfmlr/pyflowchart/issues/28
+import sys
+
+if sys.version_info < (3, 9):
+    import astunparse
+else:
+    import ast as astunparse
 
 
 def flowchart_translate_test(name='flowchart test'):
@@ -433,6 +439,21 @@ class PyflowchartTestCase(unittest.TestCase):
         flowchart = flowchart.strip()
         # ignores node id
         flowchart = re.sub(r'\d+', '*', flowchart)
+
+        # ignores brackets
+        flowchart_updated = ''
+        for line in flowchart.splitlines():
+            parts = line.split(':')
+            for i in range(1, len(parts)):
+                parts[i] = parts[i].replace('(', ' ')
+                parts[i] = parts[i].replace(')', ' ')
+            line = ':'.join(parts)
+            flowchart_updated += line + '\n'
+        flowchart = flowchart_updated
+
+        # multiple spaces to one
+        flowchart = re.sub(r'\s+', r' ', flowchart)
+
         return flowchart
 
     def test_flowchart_translate(self):

--- a/pyflowchart/test.py
+++ b/pyflowchart/test.py
@@ -52,8 +52,6 @@ e4=>end: end end
 
 st0->op1
 op1->cond2
-cond2->
-cond2->
 cond2(yes)->io3
 io3->e4
 cond2(no)->op1
@@ -452,44 +450,53 @@ class PyflowchartTestCase(unittest.TestCase):
         flowchart = flowchart_updated
 
         # multiple spaces to one
-        flowchart = re.sub(r'\s+', r' ', flowchart)
+        flowchart = re.sub(r'\t+', r' ', flowchart)
 
         return flowchart
 
     def test_flowchart_translate(self):
         got = flowchart_translate_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_FLOWCHART_TRANSLATE_TEST)
 
     def test_seq(self):
         got = seq_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_SEQ_TEST)
 
     def test_loop(self):
         got = loop_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_LOOP_TEST)
 
     def test_if(self):
         got = if_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_IF_TEST)
 
     def test_cond_loop(self):
         got = cond_loop_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_COND_LOOP_TEST)
 
     def test_func(self):
         got = func_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_FUNC_TEST)
 
     def test_from_code(self):
         got = from_code_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_FROM_CODE_TEST)
 
     def test_simplify_off(self):
         got = simplify_off_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_SIMPLIFY_OFF_TEST)
 
     def test_simplify_on(self):
         got = simplify_on_test()
+        print(got)
         self.assertEqualFlowchart(got, EXPECTED_SIMPLIFY_ON_TEST)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "rb") as fh:
 
 setuptools.setup(
     name='pyflowchart',
-    version='0.4.0-alpha.0',
+    version='0.4.0-alpha.3',
     url='https://github.com/cdfmlr/pyflowchart',
     license='MIT',
     author='CDFMLR',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "rb") as fh:
 
 setuptools.setup(
     name='pyflowchart',
-    version='0.4.0-alpha.3',
+    version='0.4.0-alpha.4',
     url='https://github.com/cdfmlr/pyflowchart',
     license='MIT',
     author='CDFMLR',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "rb") as fh:
 
 setuptools.setup(
     name='pyflowchart',
-    version='0.3.1',
+    version='0.4.0-alpha.0',
     url='https://github.com/cdfmlr/pyflowchart',
     license='MIT',
     author='CDFMLR',


### PR DESCRIPTION
- fix forward compatibility: use std `ast` instead of `astunparse` for Python 3.9+ db2a341
- refactors: introducing `Connect`, `TransparentNode`, rewrite `CondYN` 6c27872 - aaf7e3f
- feat: add `AstNode` subclasses `Match`, `MatchCase`, and `MatchCaseCondition` to parse match-case with Python 3.10+ 12fcc03


Resolves #28 